### PR TITLE
Improve the performance of constructive heap

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -254,8 +254,8 @@ class Heap {
    * @returns {Heap}
    */
   fix() {
-    for (let i = 0; i < this.size(); i += 1) {
-      this.heapifyUp(i);
+    for (let i = Math.floor((this.size() - 2) / 2); i >= 0; i--) {
+      this._heapifyDown(i);
     }
     return this;
   }

--- a/test/minHeap.test.js
+++ b/test/minHeap.test.js
@@ -121,8 +121,8 @@ describe('MinHeap unit tests', () => {
         { key: 30, value: 'something' },
         90,
         80,
-        50,
-        40
+        40,
+        50
       ]);
       expect(heap.extractRoot().key).to.equal(20);
       expect(heap.size()).to.equal(6);


### PR DESCRIPTION
By modifying the `fix` function, the time complexity of the `_heapify` is optimized from `O(NlogN)` to `O(N)`