### PR TITLE
Optimize `fix()`

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -241,8 +241,8 @@ class Heap {
    * @returns {Heap}
    */
   fix() {
-    for (let i = 0; i < this.size(); i += 1) {
-      this._heapifyUp(i);
+    for (let i = Math.floor(this.size() / 2) - 1; i >= 0; i -= 1) {
+      this._heapifyDown(i);
     }
     return this;
   }


### PR DESCRIPTION
This pull request is to optimize `fix()` and make the _heapify_ operation run in $O(n)$ instead of $O(n \log n)$. According to [this post](https://stackoverflow.com/a/18742428), we should start at the end of the array and move back towards the front. At each iteration, we sift an item down until it is in the correct location.

The largest index $i$ to look at is the largest one with at least one child. Say the length of array is $n$, then we must have $2i + 1 < n$, or $i < (n-1)/2$.  If $n = 2j$ is even, then $(2j-1)/2 = j-1/2$ so $j-1$ is the largest, which is $\lfloor n/2 \rfloor - 1$.  If $n = 2j+1$ is odd, then $(2j+1-1)/2 = j$ so $j-1$ is the largest, and that's again $\lfloor n/2 \rfloor - 1$.

Run the following script with Node.js v16.13.1 to provide a benchmark:

```js
const { Heap } = require('./src/heap');

const arr = [...Array(1e8).keys()];
console.time();
const heap = Heap.heapify(arr, (a, b) => b - a);  // build a max heap
console.timeEnd();
```

The performance difference is significant:

| `_heapifyDown()`  | `_heapifyUp()` |
| ------------- | ------------- |
| ~620 ms  | ~18 s  |

Finally, the change passed all 58 test cases.